### PR TITLE
Add edid-firmware install hook for Arch-based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ As root:
 1. Create a directory `/lib/firmware/edid/`.
 2. Copy the fixed EDID `edid.bin` from this repository to `/lib/firmware/edid/`.
 3. Ensure the fixed EDID gets included in your initramfs. For Debian and derivatives, you can use the `edid-firmware` initramfs hook from this repo: copy it to `/etc/initramfs-tools/hooks/`.
-4. Recreate your initramfs, e.g. on Debian run: `update-initramfs -c -k all`.
+
+   For Arch and derivatives, you can use the `edid-firmware.arch` mkinitcpio hook from this repo: copy it as `/etc/mkinitcpio/install/edid-firmware`.
+Then, add `edid-firmware` to the HOOKS section in `/etc/mkinitcpio.conf`.
+4. Recreate your initramfs, e.g. on Debian run: `update-initramfs -c -k all`. On Arch run: `mkinitcpio --allpresets`.
 4. Modify your kernel command line to use the fixed EDID by including `drm.edid_firmware=eDP-1:edid/edid.bin`. If you use GRUB as your bootloader, add this command to `GRUB_CMDLINE_LINUX_DEFAULT` in `/etc/default/grub` and run `update-grub` thereafter.
 5. Reboot and verify you now have 120hz:
 

--- a/edid-firmware.arch
+++ b/edid-firmware.arch
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+build() {
+	add_dir /lib/firmware/edid
+	add_file /lib/firmware/edid/edid.bin /lib/firmware/edid
+}


### PR DESCRIPTION
Thank you for compiling this excellent fix!
I use an Arch system, and figured it would be helpful if my install hook were provided here. I also added additional instructions to README for getting it to work.